### PR TITLE
Limit Windows Named Pipe access to logon session

### DIFF
--- a/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeServerSocket.java
+++ b/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeServerSocket.java
@@ -21,6 +21,7 @@ import com.sun.jna.platform.win32.WinBase;
 import com.sun.jna.platform.win32.WinError;
 import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
+import com.sun.jna.platform.win32.WinBase.SECURITY_ATTRIBUTES;
 import com.sun.jna.ptr.IntByReference;
 
 import java.io.IOException;
@@ -89,6 +90,7 @@ public class Win32NamedPipeServerSocket extends ServerSocket {
             this.path = path;
         }
         String lockPath = this.path + "_lock";
+        SECURITY_ATTRIBUTES sa = Win32SecurityLibrary.createSecurityWithLogonDacl(WinNT.FILE_GENERIC_READ);
         lockHandle = API.CreateNamedPipe(
                 lockPath,
                 Win32NamedPipeLibrary.FILE_FLAG_FIRST_PIPE_INSTANCE | Win32NamedPipeLibrary.PIPE_ACCESS_DUPLEX,
@@ -97,7 +99,7 @@ public class Win32NamedPipeServerSocket extends ServerSocket {
                 BUFFER_SIZE,
                 BUFFER_SIZE,
                 0,
-                null);
+                sa);
         if (lockHandle == Win32NamedPipeLibrary.INVALID_HANDLE_VALUE) {
             throw new IOException(String.format("Could not create lock for %s, error %d", lockPath, API.GetLastError()));
         } else {
@@ -113,6 +115,7 @@ public class Win32NamedPipeServerSocket extends ServerSocket {
     }
 
     public Socket accept() throws IOException {
+        SECURITY_ATTRIBUTES sa = Win32SecurityLibrary.createSecurityWithLogonDacl(WinNT.FILE_ALL_ACCESS);
         HANDLE handle = API.CreateNamedPipe(
                 path,
                 Win32NamedPipeLibrary.PIPE_ACCESS_DUPLEX | WinNT.FILE_FLAG_OVERLAPPED,
@@ -121,7 +124,7 @@ public class Win32NamedPipeServerSocket extends ServerSocket {
                 BUFFER_SIZE,
                 BUFFER_SIZE,
                 0,
-                null);
+                sa);
         if (handle == Win32NamedPipeLibrary.INVALID_HANDLE_VALUE) {
             throw new IOException(String.format("Could not create named pipe, error %d", API.GetLastError()));
         }

--- a/src/main/java/org/scalasbt/ipcsocket/Win32SecurityLibrary.java
+++ b/src/main/java/org/scalasbt/ipcsocket/Win32SecurityLibrary.java
@@ -1,0 +1,99 @@
+package org.scalasbt.ipcsocket;
+
+import com.sun.jna.platform.win32.WinNT;
+import com.sun.jna.platform.win32.WinNT.SECURITY_DESCRIPTOR;
+import com.sun.jna.platform.win32.WinNT.PSID;
+import com.sun.jna.platform.win32.WinNT.PSIDByReference;
+import com.sun.jna.platform.win32.WinNT.HANDLEByReference;
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+import com.sun.jna.platform.win32.WinNT.SID_AND_ATTRIBUTES;
+import com.sun.jna.platform.win32.WinNT.ACL;
+import com.sun.jna.platform.win32.WinNT.ACCESS_ALLOWED_ACE;
+import com.sun.jna.platform.win32.WinDef.DWORD;
+import com.sun.jna.platform.win32.WinBase.SECURITY_ATTRIBUTES;
+import com.sun.jna.platform.win32.Advapi32;
+import com.sun.jna.platform.win32.Advapi32Util;
+import com.sun.jna.platform.win32.Kernel32;
+import com.sun.jna.platform.win32.Kernel32Util;
+import com.sun.jna.platform.win32.W32Errors;
+import com.sun.jna.ptr.IntByReference;
+import com.sun.jna.Native;
+
+public class Win32SecurityLibrary {
+	private static final long SE_GROUP_LOGON_ID = 0xC0000000L;
+
+	public static SECURITY_ATTRIBUTES createSecurityWithLogonDacl(int accessMask) {
+		SECURITY_DESCRIPTOR sd = new SECURITY_DESCRIPTOR(64 * 1024);
+		Advapi32.INSTANCE.InitializeSecurityDescriptor(sd, WinNT.SECURITY_DESCRIPTOR_REVISION);
+		Native.getLastError();
+
+		ACL pAcl;
+		int cbAcl = 0;
+		PSIDByReference psid = new PSIDByReference();
+		getLogonSID(psid);
+		int sidLength = Advapi32.INSTANCE.GetLengthSid(psid.getValue());
+		cbAcl = Native.getNativeSize(ACL.class, null);
+		cbAcl += Native.getNativeSize(ACCESS_ALLOWED_ACE.class, null);
+		cbAcl += (sidLength - DWORD.SIZE);
+		cbAcl = Advapi32Util.alignOnDWORD(cbAcl);
+		pAcl = new ACL(cbAcl);
+		Advapi32.INSTANCE.InitializeAcl(pAcl, cbAcl, WinNT.ACL_REVISION);
+		Native.getLastError();
+		Advapi32.INSTANCE.AddAccessAllowedAce(pAcl, WinNT.ACL_REVISION, accessMask, psid.getValue());
+		Native.getLastError();
+		Advapi32.INSTANCE.SetSecurityDescriptorDacl(sd, true, pAcl, false);
+		Native.getLastError();
+
+		SECURITY_ATTRIBUTES sa = new SECURITY_ATTRIBUTES();
+		sa.dwLength = new DWORD(sd.size());
+		sa.lpSecurityDescriptor = sd.getPointer();
+		sa.bInheritHandle = false;
+
+		return sa;
+	}
+
+	public static void getOwnerSID(PSIDByReference psid) {
+		HANDLEByReference phToken = new HANDLEByReference();
+		try {
+			Advapi32.INSTANCE.OpenProcessToken(Kernel32.INSTANCE.GetCurrentProcess(), WinNT.TOKEN_QUERY, phToken);
+			Native.getLastError();
+			IntByReference tokenInformationLength = new IntByReference();
+			Advapi32.INSTANCE.GetTokenInformation(phToken.getValue(),
+				WinNT.TOKEN_INFORMATION_CLASS.TokenOwner, null, 0, tokenInformationLength);
+			WinNT.TOKEN_OWNER owner = new WinNT.TOKEN_OWNER(tokenInformationLength.getValue());
+			Advapi32.INSTANCE.GetTokenInformation(phToken.getValue(),
+				WinNT.TOKEN_INFORMATION_CLASS.TokenOwner, owner,
+				tokenInformationLength.getValue(), tokenInformationLength);
+			Native.getLastError();
+			psid.setValue(owner.Owner);
+		} finally {
+			Kernel32Util.closeHandleRef(phToken);
+		}
+	}
+
+	public static void getLogonSID(PSIDByReference psid) {
+		HANDLEByReference phToken = new HANDLEByReference();
+		try {
+			Advapi32.INSTANCE.OpenProcessToken(Kernel32.INSTANCE.GetCurrentProcess(), WinNT.TOKEN_QUERY, phToken);
+			Native.getLastError();
+			IntByReference tokenInformationLength = new IntByReference();
+			Advapi32.INSTANCE.GetTokenInformation(phToken.getValue(),
+				WinNT.TOKEN_INFORMATION_CLASS.TokenGroups, null, 0, tokenInformationLength);
+			WinNT.TOKEN_GROUPS groups = new WinNT.TOKEN_GROUPS(tokenInformationLength.getValue());
+			Advapi32.INSTANCE.GetTokenInformation(phToken.getValue(),
+				WinNT.TOKEN_INFORMATION_CLASS.TokenGroups, groups,
+				tokenInformationLength.getValue(), tokenInformationLength);
+			Native.getLastError();
+
+			for (SID_AND_ATTRIBUTES sidAndAttribute: groups.getGroups()) {
+				if ((sidAndAttribute.Attributes & SE_GROUP_LOGON_ID) == SE_GROUP_LOGON_ID) {
+					psid.setValue(sidAndAttribute.Sid);
+					return;
+				}
+			}
+			throw new RuntimeException("LogonSID was not found.");
+		} finally {
+			Kernel32Util.closeHandleRef(phToken);
+		}
+	}
+}


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/3938

https://msdn.microsoft.com/en-us/library/windows/desktop/aa365600(v=vs.85).aspx

> To prevent remote users or users on a different terminal services session from accessing a named pipe, use the logon SID on the DACL for the pipe. 

This constructs a DACL (discretionary access control list) that limits the read/write rights to current logon session (Logon SID), and passes it in to create the named pipe.

/cc @jameskoch2
