### PR TITLE
adding better toString support && stopping javac unnecessary warnings

### DIFF
--- a/src/main/java/org/scalasbt/ipcsocket/CloseCallback.java
+++ b/src/main/java/org/scalasbt/ipcsocket/CloseCallback.java
@@ -1,0 +1,59 @@
+/*
+
+ Copyright 2004-2017, Martian Software, Inc.
+
+ Licensed under the Apache License, Version 2.0 (the "License");
+ you may not use this file except in compliance with the License.
+ You may obtain a copy of the License at
+
+ http://www.apache.org/licenses/LICENSE-2.0
+
+ Unless required by applicable law or agreed to in writing, software
+ distributed under the License is distributed on an "AS IS" BASIS,
+ WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ See the License for the specific language governing permissions and
+ limitations under the License.
+
+ */
+package org.scalasbt.ipcsocket;
+
+import com.sun.jna.platform.win32.WinNT.HANDLE;
+
+import java.io.IOException;
+import java.util.concurrent.LinkedBlockingQueue;
+
+public class CloseCallback {
+
+    private static final Win32NamedPipeLibrary API = Win32NamedPipeLibrary.INSTANCE;
+    private final LinkedBlockingQueue<HANDLE> connectedHandles;
+    private final LinkedBlockingQueue<HANDLE> openHandles;
+    private final Win32NamedPipeServerSocket win32NamedPipeServerSocket;
+
+    public CloseCallback(final Win32NamedPipeServerSocket win32NamedPipeServerSocket,
+                            final LinkedBlockingQueue<HANDLE> connectedHandles,
+                            final LinkedBlockingQueue<HANDLE> openHandles){
+        this.win32NamedPipeServerSocket = win32NamedPipeServerSocket;
+        this.connectedHandles = connectedHandles;
+        this.openHandles = openHandles;
+    }
+
+    public CloseCallback(){
+        this.win32NamedPipeServerSocket = null;
+        this.connectedHandles = null;
+        this.openHandles = null;
+    }
+
+    public void onNamedPipeSocketClose(HANDLE handle) throws IOException {
+        if(win32NamedPipeServerSocket != null
+            && connectedHandles != null
+            && openHandles != null){
+            if (connectedHandles.remove(handle)) {
+                win32NamedPipeServerSocket.closeConnectedPipe(handle, false);
+            }
+            if (openHandles.remove(handle)) {
+                win32NamedPipeServerSocket.closeOpenPipe(handle);
+            }
+        }
+    }
+
+}

--- a/src/main/java/org/scalasbt/ipcsocket/ReferenceCountedFileDescriptor.java
+++ b/src/main/java/org/scalasbt/ipcsocket/ReferenceCountedFileDescriptor.java
@@ -77,4 +77,8 @@ public class ReferenceCountedFileDescriptor {
       throw new IOException(e);
     }
   }
+
+  public String toString() {
+    return Integer.toString(fd);
+  }
 }

--- a/src/main/java/org/scalasbt/ipcsocket/UnixDomainSocket.java
+++ b/src/main/java/org/scalasbt/ipcsocket/UnixDomainSocket.java
@@ -40,6 +40,7 @@ public class UnixDomainSocket extends Socket {
   private final ReferenceCountedFileDescriptor fd;
   private final InputStream is;
   private final OutputStream os;
+  private final String path;
 
   /**
    * Creates a Unix domain socket backed by a file path.
@@ -58,6 +59,7 @@ public class UnixDomainSocket extends Socket {
       this.fd = new ReferenceCountedFileDescriptor(socketFd);
       this.is = new UnixDomainSocketInputStream();
       this.os = new UnixDomainSocketOutputStream();
+      this.path = path;
     } catch (LastErrorException e) {
       throw new IOException(e);
     }
@@ -70,6 +72,7 @@ public class UnixDomainSocket extends Socket {
     this.fd = new ReferenceCountedFileDescriptor(fd);
     this.is = new UnixDomainSocketInputStream();
     this.os = new UnixDomainSocketOutputStream();
+    this.path = null;
   }
 
   public InputStream getInputStream() {
@@ -113,6 +116,15 @@ public class UnixDomainSocket extends Socket {
     } catch (LastErrorException e) {
       throw new IOException(e);
     }
+  }
+
+  public String toString() {
+    if(path != null)
+      return "Socket[type=UnixDomain,path=" + path + "]";
+    else if(fd != null)
+      return "Socket[type=UnixDomain,fd=" + fd + "]";
+    else
+      return "Socket[type=UnixDomain,unknown]";
   }
 
   private class UnixDomainSocketInputStream extends InputStream {

--- a/src/main/java/org/scalasbt/ipcsocket/UnixDomainSocketLibrary.java
+++ b/src/main/java/org/scalasbt/ipcsocket/UnixDomainSocketLibrary.java
@@ -60,7 +60,7 @@ public class UnixDomainSocketLibrary {
       public byte sunLen;
       public byte sunFamily;
 
-      protected List getFieldOrder() {
+      protected List<String> getFieldOrder() {
         return Arrays.asList(new String[] { "sunLen", "sunFamily" });
       }
     }
@@ -114,7 +114,7 @@ public class UnixDomainSocketLibrary {
       allocateMemory();
     }
 
-    protected List getFieldOrder() {
+    protected List<String> getFieldOrder() {
       return Arrays.asList(new String[] { "sunFamily", "sunPath" });
     }
   }

--- a/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeServerSocket.java
+++ b/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeServerSocket.java
@@ -196,4 +196,8 @@ public class Win32NamedPipeServerSocket extends ServerSocket {
         API.DisconnectNamedPipe(handle);
         API.CloseHandle(handle);
     }
+
+  public String toString() {
+    return "ServerSocket[type=Win32NamedPipe,path=" + path + "]";
+  }
 }

--- a/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeSocket.java
+++ b/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeSocket.java
@@ -42,12 +42,6 @@ public class Win32NamedPipeSocket extends Socket {
             0,     // default attributes
             null); // no template file
     }
-    private static CloseCallback emptyCallback() {
-        return new CloseCallback() {
-            public void onNamedPipeSocketClose(HANDLE handle) throws IOException {
-            }
-        };
-    }
 
     static final boolean DEFAULT_REQUIRE_STRICT_LENGTH = false;
     private final HANDLE handle;
@@ -58,10 +52,6 @@ public class Win32NamedPipeSocket extends Socket {
     private final HANDLE readerWaitable;
     private final HANDLE writerWaitable;
     private String pipeName;
-
-    interface CloseCallback {
-        void onNamedPipeSocketClose(HANDLE handle) throws IOException;
-    }
 
     /**
      * The doc for InputStream#read(byte[] b, int off, int len) states that
@@ -96,7 +86,7 @@ public class Win32NamedPipeSocket extends Socket {
     }
 
     public Win32NamedPipeSocket(String pipeName) throws IOException {
-        this(createFile(pipeName), emptyCallback(), DEFAULT_REQUIRE_STRICT_LENGTH);
+        this(createFile(pipeName), new CloseCallback(), DEFAULT_REQUIRE_STRICT_LENGTH);
         this.pipeName = pipeName;
     }
 

--- a/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeSocket.java
+++ b/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeSocket.java
@@ -57,6 +57,7 @@ public class Win32NamedPipeSocket extends Socket {
     private final OutputStream os;
     private final HANDLE readerWaitable;
     private final HANDLE writerWaitable;
+    private String pipeName;
 
     interface CloseCallback {
         void onNamedPipeSocketClose(HANDLE handle) throws IOException;
@@ -91,10 +92,12 @@ public class Win32NamedPipeSocket extends Socket {
             HANDLE handle,
             CloseCallback closeCallback) throws IOException {
         this(handle, closeCallback, DEFAULT_REQUIRE_STRICT_LENGTH);
+        this.pipeName = null;
     }
 
     public Win32NamedPipeSocket(String pipeName) throws IOException {
         this(createFile(pipeName), emptyCallback(), DEFAULT_REQUIRE_STRICT_LENGTH);
+        this.pipeName = pipeName;
     }
 
     @Override
@@ -119,6 +122,13 @@ public class Win32NamedPipeSocket extends Socket {
     @Override
     public void shutdownOutput() throws IOException {
     }
+
+  public String toString() {
+    if(pipeName != null)
+      return "Socket[type=Win32NamedPipe,name=" + pipeName + ",handle=" + handle + "]";
+    else
+      return "Socket[type=Win32NamedPipe,handle=" + handle + "]";
+  }
 
     private class Win32NamedPipeSocketInputStream extends InputStream {
         private final HANDLE handle;


### PR DESCRIPTION
Hello everyone, I discovered ipcsocket yesterday and have found it very useful.  In an application I am using it in, I found that unlike IP sockets which have useful toString() information such as:
Socket[addr=/192.168.1.2,port=64655,localport=3306]
When I was using your sockets I would get toString() information such as:
Socket[unconnected]
(even when the socket was connected)
I thought to remedy the situation by adding more complete and correct toString() to the unix domain sockets and the win32 named pipes.

Also, I was consistently seeing javac messages:

```
src/main/java/org/scalasbt/ipcsocket/UnixDomainSocketLibrary.java:117: warning: [unchecked] getFieldOrder() in SockaddrUn overrides getFieldOrder() in Structure
    protected List getFieldOrder() {
                   ^
  return type requires unchecked conversion from List to List<String>
src/main/java/org/scalasbt/ipcsocket/UnixDomainSocketLibrary.java:63: warning: [unchecked] getFieldOrder() in SunLenAndFamily overrides getFieldOrder() in Structure
      protected List getFieldOrder() {
                     ^
  return type requires unchecked conversion from List to List<String>
```

Stopping these messages was easy.