### PR TITLE
True overlapped i/o

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -5,7 +5,7 @@ lazy val junitInterface = "com.novocode" % "junit-interface" % "0.11"
 lazy val root = (project in file("."))
   .settings(
     inThisBuild(List(
-      version := "1.0.0-SNAPSHOT",
+      version := "1.0.1-SNAPSHOT",
       organization := "org.scala-sbt.ipcsocket",
       organizationName := "sbt",
       organizationHomepage := Some(url("http://scala-sbt.org/")),

--- a/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeSocket.java
+++ b/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeSocket.java
@@ -39,7 +39,7 @@ public class Win32NamedPipeSocket extends Socket {
             0,     // no sharing
             null,  // default security attributes
             WinNT.OPEN_EXISTING,
-            0,     // default attributes
+            WinNT.FILE_FLAG_OVERLAPPED,     // need overlapped for true asynchronous read/write access
             null); // no template file
     }
     private static CloseCallback emptyCallback() {


### PR DESCRIPTION
With the file attribute set to WinNT.FILE_FLAG_OVERLAPPED in the CreateFile, it allows reads and writes to happen at the same time. This should be the desired behavior for the named pipe library.

If you want to make this an option I can, but I thought it would be best that this is turned on automatically since that is what I expected from the named pipe library.