### PR TITLE
Make JNI server socket keep using JNI when accepting connections

### DIFF
--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.4.4
+sbt.version=1.5.3

--- a/src/main/java/org/scalasbt/ipcsocket/UnixDomainServerSocket.java
+++ b/src/main/java/org/scalasbt/ipcsocket/UnixDomainServerSocket.java
@@ -59,6 +59,7 @@ public class UnixDomainServerSocket extends ServerSocket {
   private boolean isBound;
   private boolean isClosed;
   private final UnixDomainSocketLibraryProvider provider;
+  private final boolean useJNI;
 
   public static class UnixDomainServerSocketAddress extends SocketAddress {
     private final String path;
@@ -105,6 +106,7 @@ public class UnixDomainServerSocket extends ServerSocket {
    */
   public UnixDomainServerSocket(int backlog, String path, boolean useJNI) throws IOException {
     try {
+      this.useJNI = useJNI;
       provider = UnixDomainSocketLibraryProvider.get(useJNI);
       fd = new AtomicInteger(provider.socket(PF_LOCAL, SOCK_STREAM, 0));
       this.backlog = backlog;
@@ -153,7 +155,7 @@ public class UnixDomainServerSocket extends ServerSocket {
     }
     try {
       int clientFd = provider.accept(fd.get());
-      return new UnixDomainSocket(clientFd);
+      return new UnixDomainSocket(clientFd, useJNI);
     } catch (NativeErrorException e) {
       throw new IOException(e);
     }


### PR DESCRIPTION
`UnixDomainServerSocket` needs to remember the value of `useJNI` and use that when creating a new `UnixDomainSocket` after accepting a connection.

This allows BSP connections to work on arm64, fixing https://github.com/sbt/sbt/issues/6531