### PR TITLE
Fix typo in ERROR_PIPE_CONNECTED implementation

### DIFF
--- a/src/main/java/org/scalasbt/ipcsocket/JNAWin32NamedPipeLibraryProvider.java
+++ b/src/main/java/org/scalasbt/ipcsocket/JNAWin32NamedPipeLibraryProvider.java
@@ -233,7 +233,7 @@ class JNAWin32NamedPipeLibraryProvider implements Win32NamedPipeLibraryProvider 
 
   @Override
   public int ERROR_PIPE_CONNECTED() {
-    return WinError.ERROR_NO_DATA;
+    return WinError.ERROR_PIPE_CONNECTED;
   }
 
   @Override


### PR DESCRIPTION
I made this in the github editor but it looks like it should work.