### PR TITLE
Fix native library cleanup

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -99,7 +99,6 @@ buildWin32 / skip := {
   isWin || Try(s"which ${(buildWin32 / nativeCompiler).value}".!!).fold(_ => true, _.isEmpty)
 }
 Test / fork := true
-Test / javaOptions += s"-Dsbt.ipcsocket.tmpdir=${(Compile / target).value}/jni"
 Test / fullClasspath :=
   (Test / fullClasspath).dependsOn(buildDarwin, buildLinux, buildWin32).value
 clangfmt / fileInputs += baseDirectory.value.toGlob / "jni" / "*.c"

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=1.5.3
+sbt.version=1.6.2


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/6931

Problem
-------
JNI version of the ipc-socket extracts native library
into a temp directory, and after it's done tries to delete it.
Because it uses /tmp by default, this effectively attemps to
remove empty directories it.

Solution
--------
1. Namespace it to use `.sbt` under temp.
2. Check that the file has the libsbtipcsocket prefix.