### PR TITLE
Replace WaitForSingleObject with FlushFileBuffers

### DIFF
--- a/jni/org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider.c
+++ b/jni/org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider.c
@@ -239,15 +239,15 @@ Java_org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider_CreateEventNative(
 }
 
 jint JNICALL
-Java_org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider_WaitForSingleObjectNative(
-    UNUSED JNIEnv *env, UNUSED jobject object, jlong handlePointer, jint wait) {
-  return WaitForSingleObject((HANDLE)handlePointer, wait);
-}
-
-jint JNICALL
 Java_org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider_GetLastError(
     UNUSED JNIEnv *env, UNUSED jobject object) {
   return GetLastError();
+}
+
+jboolean JNICALL
+Java_org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider_FlushFileBuffersNative(
+    UNUSED JNIEnv *env, UNUSED jobject object, jlong handlePointer) {
+  return FlushFileBuffers((HANDLE)handlePointer);
 }
 
 jlong JNICALL

--- a/jni/org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider.h
+++ b/jni/org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider.h
@@ -89,14 +89,6 @@ JNIEXPORT jlong JNICALL Java_org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProv
 
 /*
  * Class:     org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider
- * Method:    WaitForSingleObjectNative
- * Signature: (JI)I
- */
-JNIEXPORT jint JNICALL Java_org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider_WaitForSingleObjectNative
-  (JNIEnv *, jobject, jlong, jint);
-
-/*
- * Class:     org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider
  * Method:    GetLastError
  * Signature: ()I
  */
@@ -109,6 +101,14 @@ JNIEXPORT jint JNICALL Java_org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvi
  * Signature: (J)J
  */
 JNIEXPORT jlong JNICALL Java_org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider_NewOverlappedNative
+  (JNIEnv *, jobject, jlong);
+
+/*
+ * Class:     org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider
+ * Method:    FlushFileBuffersNative
+ * Signature: (J)Z
+ */
+JNIEXPORT jboolean JNICALL Java_org_scalasbt_ipcsocket_JNIWin32NamedPipeLibraryProvider_FlushFileBuffersNative
   (JNIEnv *, jobject, jlong);
 
 /*

--- a/src/main/java/org/scalasbt/ipcsocket/JNAWin32NamedPipeLibraryProvider.java
+++ b/src/main/java/org/scalasbt/ipcsocket/JNAWin32NamedPipeLibraryProvider.java
@@ -10,7 +10,6 @@ import com.sun.jna.platform.win32.WinNT;
 import com.sun.jna.platform.win32.WinNT.HANDLE;
 import com.sun.jna.platform.win32.WinBase.SECURITY_ATTRIBUTES;
 import com.sun.jna.platform.win32.WinBase.OVERLAPPED;
-import com.sun.jna.platform.win32.WinError;
 
 class JNAWin32NamedPipeLibraryProvider implements Win32NamedPipeLibraryProvider {
   static final Win32NamedPipeLibrary delegate = Win32NamedPipeLibrary.INSTANCE;
@@ -200,11 +199,6 @@ class JNAWin32NamedPipeLibraryProvider implements Win32NamedPipeLibraryProvider 
   }
 
   @Override
-  public int WaitForSingleObject(Handle hHandle, int dwMilliseconds) {
-    return delegate.WaitForSingleObject(getHandle(hHandle), dwMilliseconds);
-  }
-
-  @Override
   public int GetLastError() {
     return delegate.GetLastError();
   }
@@ -220,6 +214,10 @@ class JNAWin32NamedPipeLibraryProvider implements Win32NamedPipeLibraryProvider 
 
   @Override
   public void DeleteOverlapped(Overlapped op) {}
+
+  public boolean FlushFileBuffers(Handle handle) {
+    return delegate.FlushFileBuffers(getHandle(handle));
+  }
 
   @Override
   public int ERROR_IO_PENDING() {

--- a/src/main/java/org/scalasbt/ipcsocket/JNIWin32NamedPipeLibraryProvider.java
+++ b/src/main/java/org/scalasbt/ipcsocket/JNIWin32NamedPipeLibraryProvider.java
@@ -152,13 +152,6 @@ class JNIWin32NamedPipeLibraryProvider implements Win32NamedPipeLibraryProvider 
   native long CreateEventNative(boolean bManualReset, boolean bInitialState, String lpName);
 
   @Override
-  public int WaitForSingleObject(Handle hHandle, int dwMilliseconds) {
-    return WaitForSingleObjectNative(getHandlePointer(hHandle), dwMilliseconds);
-  }
-
-  native int WaitForSingleObjectNative(long pointer, int dwMilliseconds);
-
-  @Override
   public native int GetLastError();
 
   @Override
@@ -171,6 +164,13 @@ class JNIWin32NamedPipeLibraryProvider implements Win32NamedPipeLibraryProvider 
   @Override
   public void DeleteOverlapped(Overlapped overlapped) {
     DeleteOverlappedNative(getOverlappedPointer(overlapped));
+  }
+
+  native boolean FlushFileBuffersNative(long handle);
+
+  @Override
+  public boolean FlushFileBuffers(Handle handle) {
+    return FlushFileBuffersNative(getHandlePointer(handle));
   }
 
   native void DeleteOverlappedNative(long overlapped);

--- a/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeLibrary.java
+++ b/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeLibrary.java
@@ -95,7 +95,7 @@ public interface Win32NamedPipeLibrary extends Library, WinNT {
       boolean bInitialState,
       String lpName);
 
-  int WaitForSingleObject(HANDLE hHandle, int dwMilliseconds);
+  boolean FlushFileBuffers(HANDLE hObject);
 
   int GetLastError();
 }

--- a/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeLibraryProvider.java
+++ b/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeLibraryProvider.java
@@ -41,13 +41,13 @@ interface Win32NamedPipeLibraryProvider {
 
   Handle CreateEvent(boolean bManualReset, boolean bInitialState, String lpName) throws IOException;
 
-  int WaitForSingleObject(Handle hHandle, int dwMilliseconds);
-
   int GetLastError();
 
   Overlapped NewOverlapped(Handle hEvent);
 
   void DeleteOverlapped(Overlapped overlapped);
+
+  boolean FlushFileBuffers(Handle handle);
 
   // Constants:
   int ERROR_IO_PENDING();

--- a/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeServerSocket.java
+++ b/src/main/java/org/scalasbt/ipcsocket/Win32NamedPipeServerSocket.java
@@ -98,7 +98,7 @@ public class Win32NamedPipeServerSocket extends ServerSocket {
     this.closeCallback =
         handle -> {
           if (connectedHandles.remove(handle)) {
-            closeConnectedPipe(handle, false);
+            closeConnectedPipe(handle);
           }
           if (openHandles.remove(handle)) {
             closeOpenPipe(handle);
@@ -208,7 +208,7 @@ public class Win32NamedPipeServerSocket extends ServerSocket {
       List<Handle> handlesToDisconnect = new ArrayList<>();
       connectedHandles.drainTo(handlesToDisconnect);
       for (Handle handle : handlesToDisconnect) {
-        closeConnectedPipe(handle, true);
+        closeConnectedPipe(handle);
       }
     } finally {
       provider.CloseHandle(lockHandle);
@@ -220,10 +220,8 @@ public class Win32NamedPipeServerSocket extends ServerSocket {
     provider.CloseHandle(handle);
   }
 
-  private void closeConnectedPipe(Handle handle, boolean shutdown) throws IOException {
-    if (!shutdown) {
-      provider.WaitForSingleObject(handle, 10000);
-    }
+  private void closeConnectedPipe(Handle handle) throws IOException {
+    provider.FlushFileBuffers(handle);
     provider.DisconnectNamedPipe(handle);
     provider.CloseHandle(handle);
   }


### PR DESCRIPTION
Recently I've been trying this library for my own project on Windows. But during some simple tests (create server, create socket, send/receive response) I've seen strange 10 second wait time on the end of my test. After checking the code it was caused by waiting when closing the client socket.

After checking link provided in the commit that introduced it https://learn.microsoft.com/pl-pl/windows/win32/ipc/named-pipe-server-using-overlapped-i-o?redirectedfrom=MSDN I believe it's wrong for 2 reasons:

1. Waiting is on file handle, which is invalid. It should be on event handle.
2. This code does not really make sense in our case. The link provided is the situation where single thread is waiting for multiple pipes (I guess kinda like select on multiple channels in Go) - this is not the case here. In this library thread calling read in input stream is blocked - so multiple threads. Also the code provided does not call this functions when shutting down - it just closes pipe.

However to be 100% sure all data is sent I'm flushing the pipe before closing it.