### PR TITLE
Fix the lookup of native library

### DIFF
--- a/src/main/java/org/scalasbt/ipcsocket/NativeLoader.java
+++ b/src/main/java/org/scalasbt/ipcsocket/NativeLoader.java
@@ -53,12 +53,16 @@ class NativeLoader {
       final boolean isLinux = os.startsWith("linux");
       final boolean isWindows = os.startsWith("windows");
       final boolean is64bit = System.getProperty("sun.arch.data.model", "64").equals("64");
+      String arch = System.getProperty("os.arch", "").toLowerCase();
+      if (arch.equals("amd64")) {
+        arch = "x86_64";
+      }
       if (is64bit && (isMac || isLinux || isWindows)) {
         final String extension = "." + (isMac ? "dylib" : isWindows ? "dll" : "so");
         final String libName = (isWindows ? "" : "lib") + "sbtipcsocket" + extension;
         final String prefix = isMac ? "darwin" : isLinux ? "linux" : "win32";
 
-        final String resource = prefix + "/x86_64/" + libName;
+        final String resource = prefix + "/" + arch + "/" + libName;
         final URL url = NativeLoader.class.getClassLoader().getResource(resource);
         if (url == null) throw new UnsatisfiedLinkError(resource + " not found on classpath");
         try {


### PR DESCRIPTION
Ref #33, #34

```
server: hellofoo
server: hello
server: hellofoo
server: hello
[info] Passed: Total 9, Failed 0, Errors 0, Passed 9
[success] Total time: 23 s, completed Dec 30, 2022, 8:11:07 AM
sbt:ipcsocket> exit
[info] shutting down sbt server
ubuntu@ip:~/ipcsocket$ lscpu | head
Architecture:                    aarch64
CPU op-mode(s):                  32-bit, 64-bit
Byte Order:                      Little Endian
CPU(s):                          2
On-line CPU(s) list:             0,1
Vendor ID:                       ARM
Model name:                      Neoverse-N1
Model:                           1
Thread(s) per core:              1
Core(s) per socket:              2
```
