### PR TITLE
Fixes M1 support

### DIFF
--- a/src/main/java/org/scalasbt/ipcsocket/NativeLoader.java
+++ b/src/main/java/org/scalasbt/ipcsocket/NativeLoader.java
@@ -57,6 +57,12 @@ class NativeLoader {
       if (arch.equals("amd64")) {
         arch = "x86_64";
       }
+      // https://github.com/sbt/sbt/issues/7117
+      // Currently only Linux has ARM-specific binary. The macOS binary is a universal binary,
+      // and Windows can potentially emulate x86.
+      if (isMac || isWindows) {
+        arch = "x86_64";
+      }
       if (is64bit && (isMac || isLinux || isWindows)) {
         final String extension = "." + (isMac ? "dylib" : isWindows ? "dll" : "so");
         final String libName = (isWindows ? "" : "lib") + "sbtipcsocket" + extension;


### PR DESCRIPTION
Ref https://github.com/sbt/sbt/issues/7117

Problem
-------
In
https://github.com/sbt/ipcsocket/commit/e9b01e175a50629c961071f65a924c906673ce6d we started auto detecting CPU architecture, and corresponding JNI binary. However, for macOS, we use a universal binary, so we need to hardcode to x86_64.

Solution
--------
Hardcode to x86_64 for both macOS and Windows.