### PR TITLE
update github actions OS versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -7,10 +7,10 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - os: ubuntu-20.04
+          - os: ubuntu-22.04
             java: 8
             jobtype: 1
-          - os: macos-12
+          - os: macos-13
             java: 8
             jobtype: 1
           - os: macos-14


### PR DESCRIPTION
https://github.blog/changelog/2025-01-15-github-actions-ubuntu-20-runner-image-brownout-dates-and-other-breaking-changes/

maybe `ubuntu-20.04` and `macos-12` no longer supported