### PR TITLE
Adds non-blocking test

### DIFF
--- a/src/main/java/org/scalasbt/ipcsocket/SocketChannels.java
+++ b/src/main/java/org/scalasbt/ipcsocket/SocketChannels.java
@@ -6,9 +6,13 @@ import java.net.ProtocolFamily;
 import java.net.Socket;
 import java.net.SocketAddress;
 import java.net.SocketOption;
+import java.net.SocketException;
+import java.net.SocketTimeoutException;
 import java.net.StandardProtocolFamily;
 import java.nio.ByteBuffer;
 import java.nio.channels.GatheringByteChannel;
+import java.nio.channels.SelectionKey;
+import java.nio.channels.Selector;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.nio.channels.spi.SelectorProvider;
@@ -16,10 +20,14 @@ import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Set;
 
 public abstract class SocketChannels {
+  static boolean isJava17Plus() {
+    return ServerSocketChannels.isJava17Plus();
+  }
 
   public static SocketChannel newSocketChannel(final String pathName, final boolean jni)
       throws IOException {
@@ -33,7 +41,7 @@ public abstract class SocketChannels {
   public static SocketChannel newUnixDomainSocket(final String pathName, final boolean jni)
       throws IOException {
     SocketChannel result;
-    if (ServerSocketChannels.isJava17Plus()) {
+    if (isJava17Plus()) {
       try {
         result = newJdkUnixDomainSocket(pathName);
       } catch (ReflectiveOperationException e) {
@@ -45,21 +53,40 @@ public abstract class SocketChannels {
     return result;
   }
 
-  /** Utility function to read until newline. */
-  public static String readLine(SocketChannel channel) throws IOException {
+  /** Utility function to read until newline from a non-blocking channel. */
+  public static String readLine(SocketChannel channel, int readTimeoutMilis) throws IOException {
     int readBytes;
     byte b;
     final List<Byte> values = new ArrayList<>();
     final int bufSize = 1;
     final ByteBuffer buf = ByteBuffer.allocate(bufSize);
     do {
-      buf.rewind();
-      readBytes = channel.read(buf);
-      if (readBytes == 1) {
-        b = buf.get(0);
-        values.add(b);
-      } else {
-        b = 0;
+      try (Selector sel = Selector.open()) {
+        buf.rewind();
+        int numOfKeys = -1;
+        if (isJava17Plus() && !ServerSocketChannels.isWin) {
+          channel.register(sel, SelectionKey.OP_READ);
+          numOfKeys = sel.select(readTimeoutMilis);
+        } else {
+          if (readTimeoutMilis > 0) {
+            throw new IOException("timeout is unsupported on JDK 8");
+          }
+          if (channel.supportedOptions().contains(SO_TIMEOUT)) {
+            channel.setOption(SO_TIMEOUT, Integer.valueOf(readTimeoutMilis));
+          }
+        }
+        if (numOfKeys == 0) {
+          throw new SocketTimeoutException(
+              "readLine timed out after " + Integer.toString(readTimeoutMilis) + " msec");
+        } else {
+          readBytes = channel.read(buf);
+        }
+        if (readBytes == 1) {
+          b = buf.get(0);
+          values.add(b);
+        } else {
+          b = 0;
+        }
       }
     } while (readBytes > 0 && b != '\n');
     ByteBuffer buf2 = ByteBuffer.allocate(values.size());
@@ -69,18 +96,40 @@ public abstract class SocketChannels {
     return new String(buf2.array(), StandardCharsets.UTF_8).replace("\n", "").replace("\r", "");
   }
 
-  /** Utility function to read what's in the channel. */
-  public static ByteBuffer readAll(SocketChannel channel) throws IOException {
+  /** Utility function to read all buffer from a non-blocking channel. */
+  public static ByteBuffer readAll(SocketChannel channel, int readTimeoutMilis) throws IOException {
     int readBytes;
     final List<Byte> values = new ArrayList<>();
     final int bufSize = 1024 * 1024;
     final ByteBuffer buf = ByteBuffer.allocate(bufSize);
     do {
-      buf.rewind();
-      readBytes = channel.read(buf);
-      if (readBytes > 0) {
-        for (int i = 0; i < readBytes; i++) {
-          values.add(buf.get(i));
+      try (Selector sel = Selector.open()) {
+        buf.rewind();
+        int numOfKeys = -1;
+        if (isJava17Plus() && !ServerSocketChannels.isWin) {
+          channel.register(sel, SelectionKey.OP_READ);
+          numOfKeys = sel.select(readTimeoutMilis);
+        } else {
+          if (readTimeoutMilis > 0) {
+            throw new IOException("timeout is unsupported on JDK 8");
+          }
+          // The following operation gets blocked on JDK 8
+          // channel.register(sel, SelectionKey.OP_READ);
+          // numOfKeys = sel.select(readTimeoutMilis);
+          if (channel.supportedOptions().contains(SO_TIMEOUT)) {
+            channel.setOption(SO_TIMEOUT, Integer.valueOf(readTimeoutMilis));
+          }
+        }
+        if (numOfKeys == 0) {
+          throw new SocketTimeoutException(
+              "readAll timed out after " + Integer.toString(readTimeoutMilis) + " msec");
+        } else {
+          readBytes = channel.read(buf);
+        }
+        if (readBytes > 0) {
+          for (int i = 0; i < readBytes; i++) {
+            values.add(buf.get(i));
+          }
         }
       }
     } while (readBytes == bufSize);
@@ -107,7 +156,7 @@ public abstract class SocketChannels {
     return new ForwardingSocketChannel(socket);
   }
 
-  private static final class ForwardingSocketChannel extends SocketChannel {
+  static final class ForwardingSocketChannel extends SocketChannel {
     private final Socket socket;
 
     private ForwardingSocketChannel(Socket socket) {
@@ -203,11 +252,6 @@ public abstract class SocketChannels {
     }
 
     @Override
-    public final <A1> SocketChannel setOption(SocketOption<A1> name, A1 value) throws IOException {
-      return this;
-    }
-
-    @Override
     public final SocketChannel bind(SocketAddress local) throws IOException {
       this.socket.bind(local);
       return this;
@@ -223,12 +267,54 @@ public abstract class SocketChannels {
 
     @Override
     public final Set<SocketOption<?>> supportedOptions() {
-      return Collections.EMPTY_SET;
+      Set<SocketOption<?>> set = new HashSet();
+      set.add(SO_TIMEOUT);
+      return set;
     }
 
     @Override
-    public final <A1> A1 getOption(SocketOption<A1> name) {
+    public final <A1> A1 getOption(SocketOption<A1> name) throws SocketException {
+      if (name == SO_TIMEOUT) {
+        return (A1) Integer.valueOf(this.socket.getSoTimeout());
+      }
       return null;
+    }
+
+    @Override
+    public final <A1> SocketChannel setOption(SocketOption<A1> name, A1 value) throws IOException {
+      if (name == SO_TIMEOUT) {
+        Integer i = (Integer) value;
+        this.socket.setSoTimeout(i);
+      }
+      return this;
+    }
+  }
+
+  public static final SocketOption<Integer> SO_TIMEOUT =
+      new CustomSocketOption<Integer>("SO_TIMEOUT", Integer.class);
+
+  private static class CustomSocketOption<A1> implements SocketOption<A1> {
+    private final String name;
+    private final Class<A1> type;
+
+    CustomSocketOption(String name, Class<A1> type) {
+      this.name = name;
+      this.type = type;
+    }
+
+    @Override
+    public String name() {
+      return name;
+    }
+
+    @Override
+    public Class<A1> type() {
+      return type;
+    }
+
+    @Override
+    public String toString() {
+      return name;
     }
   }
 }

--- a/src/test/java/org/scalasbt/ipcsocket/EchoServer.java
+++ b/src/test/java/org/scalasbt/ipcsocket/EchoServer.java
@@ -2,13 +2,19 @@ package org.scalasbt.ipcsocket;
 
 import java.io.File;
 import java.io.IOException;
+import java.net.SocketTimeoutException;
 import java.nio.ByteBuffer;
 import java.nio.channels.ServerSocketChannel;
 import java.nio.channels.SocketChannel;
 import java.util.concurrent.CompletableFuture;
 
 public class EchoServer {
+  static boolean isJava17Plus() {
+    return SocketChannels.isJava17Plus();
+  }
+
   private final ServerSocketChannel serverSocketChannel;
+  private final int READ_TIMEOUT_MILI = 5000;
 
   public EchoServer(ServerSocketChannel serverSocketChannel) {
     this.serverSocketChannel = serverSocketChannel;
@@ -21,11 +27,20 @@ public class EchoServer {
       CompletableFuture.supplyAsync(
           () -> {
             try {
-              ByteBuffer inBytes = SocketChannels.readAll(clientChannel);
-              String line =
-                  new String(inBytes.array(), "UTF-8").replace("\n", "").replace("\r", "");
-              System.out.println("server: " + line);
-              clientChannel.write(inBytes);
+              clientChannel.configureBlocking(false);
+              try {
+                ByteBuffer inBytes =
+                    SocketChannels.readAll(
+                        clientChannel,
+                        isJava17Plus() && !ServerSocketChannels.isWin ? READ_TIMEOUT_MILI : 0);
+                final String line =
+                    new String(inBytes.array(), "UTF-8").replace("\n", "").replace("\r", "");
+                System.out.println("server: " + line);
+                clientChannel.write(inBytes);
+              } catch (SocketTimeoutException e) {
+                System.out.println("server read timeout");
+                return false;
+              }
             } catch (IOException e) {
               e.printStackTrace();
             }

--- a/src/test/java/org/scalasbt/ipcsocket/SocketChannelTest.java
+++ b/src/test/java/org/scalasbt/ipcsocket/SocketChannelTest.java
@@ -1,0 +1,72 @@
+package org.scalasbt.ipcsocket;
+
+import java.io.IOException;
+import java.net.SocketTimeoutException;
+import java.nio.ByteBuffer;
+import java.nio.channels.ServerSocketChannel;
+import java.nio.channels.SocketChannel;
+import java.util.concurrent.CompletableFuture;
+import org.junit.Test;
+import static org.junit.Assert.*;
+
+public class SocketChannelTest extends BaseSocketSetup {
+  static boolean isJava17Plus() {
+    return SocketChannels.isJava17Plus();
+  }
+
+  @Test
+  public void testEchoServer() throws IOException, InterruptedException {
+    System.out.println("SocketChannelTest#testEchoServer(" + Boolean.toString(useJNI()) + ")");
+    withSocket(
+        sock -> {
+          String line = echoServerTest(sock, ServerSocketChannels.isWin ? 0 : 100);
+          assertEquals("echo did not return the content", "hello", line);
+        });
+  }
+
+  @Test
+  public void testTimeout() throws IOException, InterruptedException {
+    System.out.println("SocketChannelTest#testTimeout(" + Boolean.toString(useJNI()) + ")");
+    withSocket(
+        sock -> {
+          if (isJava17Plus() && !ServerSocketChannels.isWin) {
+            String line = echoServerTest(sock, 6000);
+            assertEquals("echo did not timeout", "<timeout>", line);
+          }
+        });
+  }
+
+  private String echoServerTest(String sock, int sleepBeforeSend)
+      throws IOException, InterruptedException {
+    ServerSocketChannel serverSocket = ServerSocketChannels.newServerSocketChannel(sock, useJNI());
+    CompletableFuture<Boolean> server =
+        CompletableFuture.supplyAsync(
+            () -> {
+              try {
+                EchoServer echo = new EchoServer(serverSocket);
+                echo.run();
+              } catch (IOException e) {
+                // e.printStackTrace();
+              }
+              return true;
+            });
+    Thread.sleep(100);
+    SocketChannel client = SocketChannels.newSocketChannel(sock.toString(), useJNI());
+    System.out.println("client: " + client.toString());
+    Thread.sleep(sleepBeforeSend);
+    client.write(ByteBuffer.wrap("hello\n".getBytes("UTF-8")));
+    Thread.sleep(100);
+    client.configureBlocking(false);
+    String line;
+    try {
+      line =
+          SocketChannels.readLine(client, isJava17Plus() && !ServerSocketChannels.isWin ? 500 : 0);
+    } catch (SocketTimeoutException e) {
+      line = "<timeout>";
+    }
+    client.close();
+    server.cancel(true);
+    serverSocket.close();
+    return line;
+  }
+}

--- a/src/test/java/org/scalasbt/ipcsocket/SocketTest.java
+++ b/src/test/java/org/scalasbt/ipcsocket/SocketTest.java
@@ -1,60 +1,14 @@
 package org.scalasbt.ipcsocket;
 
-import java.io.BufferedReader;
-import java.io.File;
-import java.io.InputStream;
-import java.io.InputStreamReader;
 import java.io.IOException;
-import java.io.OutputStream;
-import java.io.PrintWriter;
-import java.nio.ByteBuffer;
-import java.nio.channels.ServerSocketChannel;
-import java.nio.channels.SocketChannel;
+import java.net.ServerSocket;
+import java.net.Socket;
 import java.nio.file.Files;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import org.junit.Test;
 import static org.junit.Assert.*;
-import java.net.ServerSocket;
-import java.net.Socket;
-import java.util.concurrent.CompletableFuture;
-import java.util.function.Consumer;
 
 public class SocketTest extends BaseSocketSetup {
-
-  @Test
-  public void testAssertEquals() throws IOException, InterruptedException {
-    withSocket(
-        sock -> {
-          System.out.println("SocketTest#testAssertEquals(" + Boolean.toString(useJNI()) + ")");
-
-          ServerSocketChannel serverSocket =
-              ServerSocketChannels.newServerSocketChannel(sock, useJNI());
-
-          CompletableFuture<Boolean> server =
-              CompletableFuture.supplyAsync(
-                  () -> {
-                    try {
-                      EchoServer echo = new EchoServer(serverSocket);
-                      echo.run();
-                    } catch (IOException e) {
-                      // e.printStackTrace();
-                    }
-                    return true;
-                  });
-          Thread.sleep(100);
-          SocketChannel client = SocketChannels.newSocketChannel(sock.toString(), useJNI());
-          System.out.println("client: " + client.toString());
-          client.write(ByteBuffer.wrap("hello\n".getBytes("UTF-8")));
-          Thread.sleep(100);
-          String line = SocketChannels.readLine(client);
-          client.close();
-          server.cancel(true);
-          serverSocket.close();
-          assertEquals("echo did not return the content", line, "hello");
-        });
-  }
-
   @Test
   public void throwIOExceptionOnMissingFile() throws IOException, InterruptedException {
     withSocket(


### PR DESCRIPTION
On JDK 17 non-blocking usage (with timeout) works. On JDK 8, I don't think we support it currently.