### PR TITLE
Fix ArrayIndexOutOfBoundsException error when socket is closed

### DIFF
--- a/jni/org_scalasbt_ipcsocket_JNIUnixDomainSocketLibraryProvider.c
+++ b/jni/org_scalasbt_ipcsocket_JNIUnixDomainSocketLibraryProvider.c
@@ -91,7 +91,9 @@ Java_org_scalasbt_ipcsocket_JNIUnixDomainSocketLibraryProvider_readNative(
   errno = 0;
   jbyte *bytes = malloc(len);
   int bytes_read = read(fd, bytes, len);
-  (*env)->SetByteArrayRegion(env, buffer, offset, bytes_read, bytes);
+  if (bytes_read > 0) {
+    (*env)->SetByteArrayRegion(env, buffer, offset, bytes_read, bytes);
+  }
   free(bytes);
   THROW_ON_ERROR(bytes_read);
 }

--- a/src/main/java/org/scalasbt/ipcsocket/UnixDomainSocket.java
+++ b/src/main/java/org/scalasbt/ipcsocket/UnixDomainSocket.java
@@ -137,7 +137,7 @@ public class UnixDomainSocket extends Socket {
     public int read() throws IOException {
       byte[] buf = new byte[1];
       int result;
-      if (doRead(buf, 0, 1) == 0) {
+      if (doRead(buf, 0, 1) <= 0) {
         result = -1;
       } else {
         // Make sure to & with 0xFF to avoid sign extension


### PR DESCRIPTION
In a CI environment when I run `sbt "clean ; compile ; shutdown"`, a (harmless) exception is thrown because of an EOF-handling bug in this dependency.

```
Exception in thread "sbt-serverconnection-0" java.lang.ArrayIndexOutOfBoundsException
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.functions.JNIFunctions$Support.setPrimitiveArrayRegion(JNIFunctions.java:1980)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.jni.functions.JNIFunctions.SetByteArrayRegion(JNIFunctions.java:1293)
	at org.scalasbt.ipcsocket.JNIUnixDomainSocketLibraryProvider.readNative(Native Method)
	at org.scalasbt.ipcsocket.JNIUnixDomainSocketLibraryProvider.read(JNIUnixDomainSocketLibraryProvider.java:32)
	at org.scalasbt.ipcsocket.UnixDomainSocket$UnixDomainSocketInputStream.doRead(UnixDomainSocket.java:157)
	at org.scalasbt.ipcsocket.UnixDomainSocket$UnixDomainSocketInputStream.read(UnixDomainSocket.java:125)
	at sbt.protocol.JsonRpcReader$.run$1(JsonRpcReader.scala:51)
	at sbt.protocol.JsonRpcReader$.read(JsonRpcReader.scala:107)
	at sbt.protocol.ServerSessionImpl$$anon$1.run(ServerSessionImpl.scala:101)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:832)
	at org.graalvm.nativeimage.builder/com.oracle.svm.core.thread.PlatformThreads.threadStartRoutine(PlatformThreads.java:808)
```

This is because the JNI `readNative` C code passes the return value from `read()` to `SetByteArrayRegion`, ignoring the fact that the result could be -1/EOF.

A related bug exists in the `UnixDomainSocket` `read()` method which doesn't handle -1 EOF from `read(b, o, l)` correctly.

Addresses sbt/sbt#9359 but won't close it until this is released and sbt dependency updated.